### PR TITLE
fix(TranslationsTrait): add afterSaveTranslationsTrait method for tim…

### DIFF
--- a/src/Repositories/Traits/TranslationsTrait.php
+++ b/src/Repositories/Traits/TranslationsTrait.php
@@ -78,7 +78,7 @@ trait TranslationsTrait
                     $activeField = $shouldPublishFirstLanguage || (isset($submittedLanguage) ? $submittedLanguage['published'] : false);
 
                     $fields[$locale] = [
-                        'active' => $activeField,
+                        'active' => (int) $activeField,
                     ] + $attributes->mapWithKeys(function ($attribute) use (&$fields, $locale, $localesCount, $index, $translationsFields) {
                         $attributeValue = $fields[$attribute] ?? $translationsFields[$attribute] ?? null;
 
@@ -201,6 +201,36 @@ trait TranslationsTrait
                     ->select($table . '.*');
 
                 unset($orders['locale']);
+            }
+        }
+    }
+
+    /**
+     * After save, re-enable timestamps and touch the parent model
+     * only when a translation row really changed (ignoring auto-timestamp
+     * columns that the translation table may carry).
+     *
+     * @param \Illuminate\Database\Eloquent\Model $object
+     * @param array $fields
+     * @return void
+     */
+    public function afterSaveTranslationsTrait($object, $fields)
+    {
+        if (! $this->model->isTranslatable()) {
+            return;
+        }
+
+        if ($object->relationLoaded('translations')) {
+            $timestampKeys = ['updated_at', 'created_at', 'deleted_at'];
+
+            foreach ($object->translations as $translation) {
+                $changedKeys = array_keys($translation->getChanges());
+                $meaningfulChanges = array_diff($changedKeys, $timestampKeys);
+
+                if (! empty($meaningfulChanges)) {
+                    $this->letEloquentModelBeTouched(true);
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
…estamp management

- Introduced afterSaveTranslationsTrait method to re-enable timestamps and touch the parent model only when meaningful changes occur in translation rows, ignoring auto-timestamp columns. This enhances the handling of translation updates in the model.

## Checklist
<!--- Please make sure all the following are checked before submitting: -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding missing tests or correcting existing tests
- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to our CI configuration files and scripts
- [ ] chore: Other changes that don't modify src or test files
- [ ] revert: Reverts a previous commit

## Description
<!--- Please describe your changes in detail -->

## Related Issue
<!--- Please link to the issue here if applicable: -->
