### PR TITLE
fix(useTableNames): prevent mutation of title interpolation props

### DIFF
--- a/vue/src/js/hooks/table/useTableNames.js
+++ b/vue/src/js/hooks/table/useTableNames.js
@@ -117,15 +117,21 @@ export default function useTableNames(props, context) {
       translationKey = props.editFormTitle
     }
 
-    let interpolation = isEditing ? props.formEditTitleInterpolations : props.formCreateTitleInterpolations
+    // NOTE: Build a fresh object — never mutate `props.form{Edit,Create}TitleInterpolations`.
+    // The source map holds *paths* (e.g. `{ item: 'id' }`); writing the resolved value back into
+    // it would poison the next compute, since the loop would then look up the resolved value
+    // itself (e.g. a UUID) instead of the original path — pinning the modal title to the id of
+    // the first ticket opened in the session.
+    const interpolationSource = isEditing ? props.formEditTitleInterpolations : props.formCreateTitleInterpolations
+    const interpolation = {}
 
-    for(let key in interpolation) {
-      let value = interpolation[key]
-      interpolation[key] = __isset(Module[interpolation[key]])
-        ? Module[interpolation[key]].value
-        : __isset(editedItem.value[interpolation[key]])
-          ? editedItem.value[interpolation[key]]
-          : value
+    for(let key in interpolationSource) {
+      const path = interpolationSource[key]
+      interpolation[key] = __isset(Module[path])
+        ? Module[path].value
+        : __isset(editedItem.value[path])
+          ? editedItem.value[path]
+          : path
     }
 
     return te(translationKey) ? t(translationKey, interpolation) : translationKey


### PR DESCRIPTION
- Refactored the interpolation logic to build a fresh object instead of mutating props.form{Edit,Create}TitleInterpolations.
- Ensured that the original paths are preserved to avoid issues with subsequent computations.

## Checklist
<!--- Please make sure all the following are checked before submitting: -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding missing tests or correcting existing tests
- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to our CI configuration files and scripts
- [ ] chore: Other changes that don't modify src or test files
- [ ] revert: Reverts a previous commit

## Description
<!--- Please describe your changes in detail -->

## Related Issue
<!--- Please link to the issue here if applicable: -->
